### PR TITLE
Have Babel strip propTypes

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -9,7 +9,7 @@ const presets = [
 const plugins = [
   ['emotion', { autoLabel: true }],
   'transform-decorators-legacy',
-  ['transform-react-remove-prop-types', { mode: 'wrap' }],
+  ['transform-react-remove-prop-types'],
   [
     '@babel/plugin-transform-runtime',
     { helpers: false, polyfill: false, regenerator: true },


### PR DESCRIPTION
Just had a look into this and noticed the author says:

> The wrap modes are targeting React libraries like material-ui or react-native-web. They are not intended to be used by application authors.

...so I removed the wrap mode config and now the propType definitions are completely removed from the transpiled files.