### PR TITLE
Change ArrayObjectTable defaultTransform

### DIFF
--- a/API.md
+++ b/API.md
@@ -76,7 +76,7 @@ const defaultTransform = value => (value || '-');
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
  `array` | true | `````` | arrayOf[object Object] | 
- `defaultTransform` |  | ```value => (value ? value : '-')``` | func | 
+ `defaultTransform` |  | ```(value = '-') => value``` | func | 
  `fields` | true | `````` | arrayOf[object Object] | 
  `hideWithNoValues` |  | ```false``` | bool | 
  `skipEmptyRows` |  | ```false``` | bool | 
@@ -344,56 +344,6 @@ Prop | Required | Default | Type | Description
  `title` |  | `````` | node | 
 
 
-Arrow
-=====
-
-### Import
-```js
-  import Arrow from '@govuk-frederic/arrow';
-```
-<!-- STORY -->
-
-### Usage
-
-Simple
-```jsx
-<Arrow />
-```
-
-### Properties
-Prop | Required | Default | Type | Description
-:--- | :------- | :------ | :--- | :----------
- `fill` |  | ```'#0C60A2'``` | string | 
- `width` |  | ```20``` | number | 
-
-
-OpenButton
-==========
-
-### Import
-```js
-  import OpenButton from '@govuk-frederic/open-button';
-```
-<!-- STORY -->
-
-### Usage
-
-Simple
-```jsx
-import manageState from 'manage-state';
-
-const ManagedOpenButton = manageState(OpenButton, { propsToState: ['open']});
-
-<ManagedOpenButton />
-```
-
-### Properties
-Prop | Required | Default | Type | Description
-:--- | :------- | :------ | :--- | :----------
- `onChange` |  | `````` | func | 
- `open` |  | `````` | bool | 
-
-
 Count
 =====
 
@@ -448,7 +398,7 @@ const ManagedCountdownTextarea = manageState(CountdownTextArea, {
  changeEvent: true,
  propsToState: ['value'],
 });
- 
+
 <ManagedCountdownTextarea noMaxLengthAttr maxLength={150} />
 ```
 
@@ -1059,56 +1009,6 @@ Prop | Required | Default | Type | Description
  `onChange` |  | `````` | func | 
  `open` |  | ```false``` | bool | 
  `title` |  | `````` | node | 
-
-
-Arrow
-=====
-
-### Import
-```js
-  import Arrow from '@govuk-frederic/arrow';
-```
-<!-- STORY -->
-
-### Usage
-
-Simple
-```jsx
-<Arrow />
-```
-
-### Properties
-Prop | Required | Default | Type | Description
-:--- | :------- | :------ | :--- | :----------
- `fill` |  | ```'#0C60A2'``` | string | 
- `width` |  | ```20``` | number | 
-
-
-OpenButton
-==========
-
-### Import
-```js
-  import OpenButton from '@govuk-frederic/open-button';
-```
-<!-- STORY -->
-
-### Usage
-
-Simple
-```jsx
-import manageState from 'manage-state';
-
-const ManagedOpenButton = manageState(OpenButton, { propsToState: ['open']});
-
-<ManagedOpenButton />
-```
-
-### Properties
-Prop | Required | Default | Type | Description
-:--- | :------- | :------ | :--- | :----------
- `onChange` |  | `````` | func | 
- `open` |  | `````` | bool | 
 
 
 Table

--- a/components/array-object-table/README.md
+++ b/components/array-object-table/README.md
@@ -76,7 +76,7 @@ const defaultTransform = value => (value || '-');
 Prop | Required | Default | Type | Description
 :--- | :------- | :------ | :--- | :----------
  `array` | true | `````` | arrayOf[object Object] | 
- `defaultTransform` |  | ```value => (value ? value : '-')``` | func | 
+ `defaultTransform` |  | ```(value = '-') => value``` | func | 
  `fields` | true | `````` | arrayOf[object Object] | 
  `hideWithNoValues` |  | ```false``` | bool | 
  `skipEmptyRows` |  | ```false``` | bool | 

--- a/components/array-object-table/src/index.js
+++ b/components/array-object-table/src/index.js
@@ -109,7 +109,7 @@ ArrayObjectTable.propTypes = {
 ArrayObjectTable.defaultProps = {
   hideWithNoValues: false,
   skipEmptyRows: false,
-  defaultTransform: value => (value ? value : '-'), /* "||" breaks api-docs formatting! */
+  defaultTransform: (value = '-') => value,
   title: null,
 };
 

--- a/components/countdown-text-area/README.md
+++ b/components/countdown-text-area/README.md
@@ -29,7 +29,7 @@ const ManagedCountdownTextarea = manageState(CountdownTextArea, {
  changeEvent: true,
  propsToState: ['value'],
 });
- 
+
 <ManagedCountdownTextarea noMaxLengthAttr maxLength={150} />
 ```
 

--- a/components/object-table/src/__snapshots__/test.js.snap
+++ b/components/object-table/src/__snapshots__/test.js.snap
@@ -61,6 +61,7 @@ exports[`ObjectTable matches snapshot 1`] = `
 }
 
 <ObjectTable
+  defaultTransform={[Function]}
   fields={
     Array [
       Object {

--- a/components/object-table/src/index.js
+++ b/components/object-table/src/index.js
@@ -88,6 +88,7 @@ ObjectTable.defaultProps = {
   object: {},
   hideWithNoValues: false,
   skipEmptyValues: false,
+  defaultTransform: (value = '-') => value,
   title: null,
 };
 

--- a/packages/utils/src/tableUtils/index.js
+++ b/packages/utils/src/tableUtils/index.js
@@ -34,8 +34,13 @@ export const rowsFromObject = (object, fields, skipEmptyValues, defaultTransform
     (table, { key, heading, names, transform = defaultTransform}) => {
       // If there is a name attribute in the fields object use it, otherwise fallback to the key
       const nameAttribute = names ? names : key;
-      // Run any passed transforms and normalise undefined values to an empty string
-      const result = transform(object[key], object) || '';
+      // Run any passed transforms
+      let result = transform(object[key], object);
+
+      // Normalise undefined values to empty strings
+      if (result === undefined) {
+        result = '';
+      }
 
       // Empty values are empty strings (normalised above)
       // We never render null

--- a/packages/utils/src/tableUtils/index.js
+++ b/packages/utils/src/tableUtils/index.js
@@ -27,7 +27,6 @@ export const rowsFromArray = (array, fields, skipEmptyRows, defaultTransform = v
 };
 
 // TODO: ALL THE DOCS
-// TODO: SOME TESTS
 // Empty values and keys are treated the same
 export const rowsFromObject = (object, fields, skipEmptyValues, defaultTransform = value => value) => {
   return fields.reduce(

--- a/packages/utils/src/tableUtils/index.js
+++ b/packages/utils/src/tableUtils/index.js
@@ -12,7 +12,7 @@ export function keysFromFields(fields) {
 
 export const titlesFromFields = fields => fields.map(field => field.heading || field.title);
 
-export const rowsFromArray = (array, fields, skipEmptyRows, defaultTransform = value => (value || '-')) => {
+export const rowsFromArray = (array, fields, skipEmptyRows, defaultTransform = value => value) => {
   const keys = keysFromFields(fields);
 
   return array.reduce((rows, item) => {

--- a/packages/utils/src/test.js
+++ b/packages/utils/src/test.js
@@ -12,12 +12,12 @@ describe('rowsFromArray', () => {
       {},
       { one: 'test', two: 'test' },
     ];
-    
+
     let rows = rowsFromArray(array, fields, false);
-    expect(rows).toEqual([['-', 'two', '-'], ['test', 'test', '-']]);
+    expect(rows).toEqual([[undefined, 'two', undefined], ['test', 'test', undefined]]);
 
     rows = rowsFromArray(array, fields, true);
-    expect(rows).toEqual([['test', 'test', '-']]);
+    expect(rows).toEqual([['test', 'test', undefined]]);
   });
 });
 
@@ -29,7 +29,7 @@ describe('rowsFromObject', () => {
       { key: 'two', heading: 'Two', transform: () => 'hardcodedstring' },
       { key: 'three', heading: 'Three' },
     ];
-    const object = { one: 'test', two: 'test', three: null };    
+    const object = { one: 'test', two: 'test', three: null };
     const skipEmptyValues = true;
     const rows = rowsFromObject(object, fields, skipEmptyValues);
 

--- a/packages/utils/src/test.js
+++ b/packages/utils/src/test.js
@@ -89,6 +89,26 @@ describe('rowsFromObject', () => {
       ],
     });
   });
+
+  it('dont render rows with null regardless of whether skipEmptyValues is set to false', () => {
+    const { rowsFromObject } = exports;
+    const fields = [
+      { key: 'one', heading: 'One' },
+      { key: 'two', heading: 'Two' },
+    ];
+    const object = { one: 'test', two: null };
+    const skipEmptyValues = false;
+    const rows = rowsFromObject(object, fields, skipEmptyValues);
+
+    expect(rows).toEqual({
+      rows: [
+        ['One', 'test'],
+      ],
+      names: [
+        'one',
+      ],
+    });
+  });
 });
 
 describe('titlesFromFields', () => {


### PR DESCRIPTION
Fixes #86 & #87 

- Don't render rows with `null` regardless of whether `skipEmptyValues` is set to `false`
- Default transform in `rowsFromArray` utility function to `value => value`
- Default transform in `ArrayObjectTable` and `ObjectTable` to `(value = '-') => value`